### PR TITLE
Document func_train rotation and per-corner keys for editors

### DIFF
--- a/target/default/scripts/entities.def
+++ b/target/default/scripts/entities.def
@@ -353,7 +353,8 @@
 
  -------- Keys --------
  target : The first path_corner of the train's route. Required.
- speed : The speed with which the train moves (default 100).
+ speed : The speed with which the train moves (default 100). This is also the speed used for any
+ path_corner that does not specify a speed of its own.
  dmg : The damage inflicted on players who block the train (default 2).
  sound : The looping sound to play while the train is in motion.
  targetname : The target name of this entity if it is to be triggered.

--- a/target/default/scripts/entities.def
+++ b/target/default/scripts/entities.def
@@ -240,7 +240,7 @@
  toggle : The door will wait in both the start and end states for a trigger event.
 */
 
-/*QUAKED func_door_rotating (0 .5 .8) ? start_open reverse toggle x_axis y_axis
+/*QUAKED func_door_rotating (0 .5 .8) ? start_open toggle reverse x_axis y_axis
  A door which rotates about an origin on its Z axis. By default, doors open when a player walks close to them.
 
  -------- Keys --------
@@ -328,6 +328,7 @@
  Time delay trigger that will continuously fire its targets after a preset time delay. The time delay can also be randomized. When triggered, the timer will toggle on/off.
 
  -------- Keys --------
+ target : The entities to fire on each tick of the timer.
  wait : Delay in seconds between each triggering of all targets (default 1).
  random : Random time variance in seconds added to "wait" delay (default 0).
  delay :  Additional delay before the first firing when start_on (default 0).
@@ -338,11 +339,20 @@
 */
 
 /*QUAKED func_train (0 .5 .8) ? start_on toggle block_stops
- Trains are moving solids that players can ride along a series of path_corners. The origin of
- each corner specifies the lower bounding point of the train at that corner. If the train is
+ Trains are moving solids that players can ride along a series of path_corners. If the train is
  the target of a button or trigger, it will not begin moving until activated.
 
+ Trains are positioned one of two ways. Given a common/origin brush, the origin of each corner
+ specifies the train's own origin at that corner, and that origin is also the point the train
+ rotates about. Without one, the origin of each corner specifies the lower bounding point of the
+ train, and the train cannot rotate.
+
+ An origin brush is therefore all it takes to make a train turn: it will face along each leg of
+ its route, turning and pitching to follow the rails, without any corner being angled by hand.
+ Angle a corner explicitly only where that is not what you want.
+
  -------- Keys --------
+ target : The first path_corner of the train's route. Required.
  speed : The speed with which the train moves (default 100).
  dmg : The damage inflicted on players who block the train (default 2).
  sound : The looping sound to play while the train is in motion.
@@ -908,6 +918,7 @@
  Warps players who touch this entity to the targeted misc_teleporter_dest entity.
 
  -------- Keys --------
+ target : The misc_teleporter_dest to warp players to. Required.
  sound : Sound to play at the teleporter and destination on use (default "misc/teleport").
 
  -------- Spawn flags --------
@@ -937,11 +948,24 @@
 
  -------- Keys --------
  pathtarget : An entity to be used by this path corner when targeted.
- target : The next corner in the path.
+ target : The next corner in the path. Point the last corner back at the first to loop a route.
  targetname : The target name of this entity.
+ wait : Seconds to wait here before moving on (default 0). With the train's toggle flag, -1 parks
+ the train here until it is triggered again. Note that the first corner's wait is not honored on
+ the first lap, so put a looping route's pause on its last corner.
+ speed : The speed the train is doing on arriving here, blended from the speed of the corner it
+ departed, so that a cart gains speed downhill and loses it climbing. Defaults to the train's own
+ speed. Avoid much above 2400, at which point the client stops smoothing the train's motion.
+ angles : The orientation the train holds on arriving here, rotating into it over the length of
+ the leg. Requires the train to have an origin brush. "angle" is accepted for yaw alone. Omit both
+ and the train faces the leg it travelled to get here, which is usually what you want.
 
  -------- Spawn flags --------
- teleport : The path corner teleports the train as soon as it is selected.
+ teleport : The train jumps to this corner rather than travelling to it, and carries straight on
+ to this corner's own target. Combine with a looping route to send a train back to its start:
+ flag the first corner teleport and no_effects, and give the last corner a wait and a target back
+ to it. Riders are not carried through the jump, and the mapper is responsible for hiding both
+ corners from view.
  no_effects : Suppress the default teleport effects.
 */
 
@@ -994,7 +1018,7 @@
  delay : The delay in seconds between activation and firing of targets (default 0.2).
  message : An optional message to display when this trigger fires.
  target : The name of the entity or team to use on activation.
- kill_target : The name of the entity or team to kill on activation.
+ killtarget : The name of the entity or team to kill on activation.
 */
 
 /*QUAKED trigger_exec (0 1 0) ?

--- a/target/default/scripts/trenchbroom/Quetoo/Quetoo.fgd
+++ b/target/default/scripts/trenchbroom/Quetoo/Quetoo.fgd
@@ -43,6 +43,8 @@
 @PointClass base(Item) color(20 180 180) studio("") = item_quad : "Quad damage" []
 @PointClass base(Item) color(204 26 26) studio("") = item_invulnerability : "Invulnerability. Grants full invulnerability for 30 seconds." []
 @PointClass base(Item) color(51 51 102) studio("") = item_invisibility : "Invisibility. Makes the player nearly invisible for 30 seconds." []
+@PointClass base(Item) color(204 26 26) studio("") = item_quake_pentagram : "Pentagram of Protection. Grants full invulnerability for 30 seconds." []
+@PointClass base(Item) color(51 51 102) studio("") = item_quake_shadows : "Ring of Shadows. Makes the player nearly invisible for 30 seconds." []
 
 @BaseClass base(Item) size(-8 -8 -24, 8 8 32) studio("") = TeamFlag []
 @PointClass base(TeamFlag) color(255 0 0) = item_flag_team1 : "Red flag" []
@@ -141,9 +143,9 @@
 [
 	spawnflags(Flags) =
 	[
-		1 : "The door to moves to its destination when spawned, and operates in reverse" : 0
-		2 : "The door will rotate in the opposite (negative) direction along its axis" : 0
-		4 : "The door will wait in both the start and end states for a trigger event" : 0
+		1 : "The door moves to its destination when spawned, and operates in reverse" : 0
+		2 : "The door will wait in both the start and end states for a trigger event" : 0
+		4 : "The door will rotate in the opposite (negative) direction along its axis" : 0
 		8 : "The door will rotate along its X axis" : 0
 		16 : "The door will rotate along its Y axis" : 0
 	]
@@ -215,7 +217,7 @@
 	delay(integer) : "Additional delay before the first firing when start_on" : 0
 ]
 
-@SolidClass base(Phong, Targetname) color(0 255 255) = func_train : "Trains are moving solids that players can ride along a series of path_corners. The origin of each corner specifies the lower bounding point of the train at that corner. If the train is the target of a button or trigger, it will not begin moving until activated."
+@SolidClass base(Phong, Target, Targetname) color(0 255 255) = func_train : "Trains are moving solids that players can ride along a series of path_corners. Target the first path_corner of the route. If the train is the target of a button or trigger, it will not begin moving until activated. Given a common/origin brush, each corner specifies the train's own origin and the train rotates about it, turning and pitching to face each leg of its route; without one, each corner specifies the train's lower bounding point and the train cannot rotate."
 [
 	spawnflags(Flags) =
 	[
@@ -224,7 +226,7 @@
 		4 : "The train will stop when blocked, and inflict no damage" : 0
 	]
 	dmg(integer) : "The damage inflicted on players who block the train" : 2
-	speed(integer) : "The speed with which the train moves" : 100
+	speed(integer) : "The speed with which the train moves, and the default for corners that omit it" : 100
 	sound(string) : "The looping sound to play while the train is in motion"
 ]
 
@@ -252,6 +254,13 @@
 
 @PointClass base(Targetname) color(0 180 0) size(-4 -4 -4, 4 4 4) = info_null : "A positional target for other entities, etc. These are inhibited in the game and are only useful to the editor and BSP compiler." []
 @PointClass base(Targetname) color(0 180 180) size(-4 -4 -4, 4 4 4) = info_notnull : "A positional target for other entities. Unlike info_null, these are available in the game and can be targeted by other entities (e.g. info_player_intermission)." []
+@PointClass color(255 0 0) size(-1 -1 -1, 1 1 1) = info_luxel : "A luxel origin, for debugging lightmap compilation. These are inhibited in the game and are only useful to the editor and BSP compiler."
+[
+	face(integer) : "The face number"
+	normal(string) : "The normal vector"
+	s(integer) : "The s coordinate"
+	t(integer) : "The t coordinate"
+]
 
 @BaseClass size(-16 -16 -24, 16 16 32) = Spawn [
 	angle(integer) : "The angle at which the player will face when spawned"
@@ -429,15 +438,18 @@
 	hz(string) : "Spawn rate in Hz" : "5"
 ]
 
-@PointClass base(Target, Targetname) color(128 76 0) size(-8 -8 -8, 8 8 8) = path_corner : "Path corner for func_trains."
+@PointClass base(Target, Targetname) color(128 76 0) size(-8 -8 -8, 8 8 8) = path_corner : "Path corner for func_trains. Point the last corner of a route back at the first, flagged teleport and silent, to loop a train back to its start."
 [
 	spawnflags(Flags) =
 	[
-		1 : "The path corner teleports the train as soon as it is selected" : 0
-		2 : "Suppress the default teleport effects" : 0
+		1 : "The train jumps to this corner instead of travelling to it, then carries on to this corner's target" : 0
+		2 : "Suppress the teleport effect" : 0
 	]
 	target(string) : "The next corner in the path"
 	pathtarget(string) : "An entity to be used by this path corner when targeted"
+	wait(float) : "Seconds to wait here before moving on; -1 with the train's toggle flag parks it here until triggered" : "0"
+	speed(integer) : "The speed the train is doing on arriving here, blended from the speed of the corner it departed. Defaults to the train's own speed. Avoid exceeding 2400, above which the client stops smoothing the train's motion"
+	angles(string) : "The orientation the train holds on arriving here, rotating into it over the leg. Requires the train to have an origin brush. Omit to have the train face its direction of travel"
 ]
 
 @PointClass base(Targetname) color(255 255 80) size(-8 -8 -8, 8 8 8) = target_light : "Emits a user-defined light when used. Lights can be chained with teams. Use this entity to add switched lights. Use the wait key to synchronize color cycles with other entities."
@@ -511,7 +523,7 @@
 	dmg(integer) : "The damage this trigger inflicts per activation" : 2
 ]
 
-@PointClass base(Target) color(128 128 128) = trigger_exec : "Executes a console command or script file when activated."
+@SolidClass color(128 128 128) = trigger_exec : "Executes a console command or script file when activated."
 [
 	command(string) : "The console command(s) to execute."
 	script(string) : "The script file (.cfg) to execute."

--- a/target/default/scripts/trenchbroom/Quetoo/Quetoo.fgd
+++ b/target/default/scripts/trenchbroom/Quetoo/Quetoo.fgd
@@ -438,7 +438,7 @@
 	hz(string) : "Spawn rate in Hz" : "5"
 ]
 
-@PointClass base(Target, Targetname) color(128 76 0) size(-8 -8 -8, 8 8 8) = path_corner : "Path corner for func_trains. Point the last corner of a route back at the first, flagged teleport and silent, to loop a train back to its start."
+@PointClass base(Target, Targetname) color(128 76 0) size(-8 -8 -8, 8 8 8) = path_corner : "Path corner for func_trains. To loop a train back to its start, point the last corner of the route at the first corner, and set both spawnflags on that first corner. Riders are not carried through the jump, and the mapper is responsible for hiding both corners from view."
 [
 	spawnflags(Flags) =
 	[


### PR DESCRIPTION
Updates `Quetoo.fgd` (TrenchBroom) and `entities.def` (Radiant) for the `func_train` work in jdolan/quetoo#943, then reconciles both files against the QUAKED blocks in the source, which turned up a number of older omissions.

Companion source-side commit: jdolan/quetoo@b40233a.

## For the func_train work

**func_train**
- Documents that it may be built around a `common/origin` brush, in which case each `path_corner` specifies the train's *own origin* rather than its lower bounding point, and the train rotates about that origin — turning and pitching to face each leg of its route with no corner angled by hand. Without an origin brush it positions and behaves exactly as before.
- Adds `target`, which defines the route and has somehow never been offered. In TrenchBroom this was worse than a documentation gap: the entity had `base(Phong, Targetname)` with no `Target`, so there was no way to point a train at its first corner from the entity inspector at all.
- Notes that the train's `speed` is the default for corners that omit one.

**path_corner**
- Adds `speed` — the speed the train is doing on arriving, blended from the speed of the corner it departed, so a cart gains speed downhill and loses it climbing.
- Adds `angles` — the orientation held on arrival, rotating into it over the leg. Documented as optional, since omitting it gets you the direction of travel, which is usually what you want.
- Adds `wait`, which `func_train` has always honored but which neither file advertised. Includes the two traps: `-1` only makes sense with the train's `toggle` flag, and the first corner's `wait` is skipped on the first lap, so a looping route's pause belongs on its last corner.
- Expands the `teleport` / `no_effects` spawnflag descriptions to explain the loop-back-to-start recipe they enable. This already worked and was simply never written down.

Deliberately **not** added: an `angles` key on `func_train` itself. The first `path_corner` always determines the starting orientation, so the train's own `angles` is inert and documenting it would mislead.

## Older gaps found while reconciling

Two of these are real bugs rather than missing prose:

- **`func_door_rotating` spawnflags were transposed in both files.** `entities.def` listed them as `start_open reverse toggle`, and the `.fgd` labelled bit 2 as reverse and bit 4 as toggle. The code has `DOOR_TOGGLE 0x2` and `DOOR_ROTATING_REVERSE 0x4`. Ticking either box in an editor therefore set the other flag. Note the descriptions in `entities.def` were already in the right order — only the positional header line was wrong.
- **`trigger_exec` was a `@PointClass` in the `.fgd`.** It is brush-based (`?` in its QUAKED block) and `G_Trigger_Init` calls `SetModel` on it, so one placed as a point entity has no model and can never fire. Now `@SolidClass`. It also carried `base(Target)` despite `G_trigger_exec_Touch` never calling `G_UseTargets`, so `target` did nothing — removed.

Missing keys:

- **`misc_teleporter`** never advertised `target`, and it frees itself outright without one.
- **`func_timer`** never advertised `target` in `entities.def`, which is what it fires on each tick.
- **`trigger_always`** documented its kill target as `kill_target` in `entities.def`; the key actually read is `killtarget`, so anyone following the docs got no kill target at all.

Missing entities:

- **`info_luxel`**, **`item_quake_pentagram`** and **`item_quake_shadows`** were absent from the `.fgd` entirely, though all three were in `entities.def`.

## How this was checked

A throwaway script parsed every QUAKED block in `src/game/common` and `src/cgame/common`, then both editor files (resolving `@BaseClass` inheritance in the `.fgd`), and diffed classes, keys, spawnflag order, and point-vs-brush shape. After these changes the only remaining difference is `trigger_multiple`, which is a false positive — it inherits from `trigger_once` via `base(trigger_once)`, a `@SolidClass` rather than a `@BaseClass`, which the script didn't follow. The `phong` key showing up as fgd-only across the brush entities is likewise expected; it's a compiler key, not a game key.

Not verified in an editor — I don't have TrenchBroom or Radiant here. Both files parse structurally (balanced brackets, balanced quotes, 101 matched QUAKED open/close pairs), but a quick load in TrenchBroom before merging would be worth it, particularly for the new `path_corner` properties.
